### PR TITLE
Fix an IndexOutOfRangeException

### DIFF
--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -148,7 +148,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
         List<TValue>? result = null;
 
-        Span<int> stack = stackalloc int[_treeHeight];
+        Span<int> stack = stackalloc int[_treeHeight + 1];
         stack[0] = 1;
         var stackIndex = 0;
 


### PR DESCRIPTION
When doing a range query with a QuickIntervalTree you could get into trouble if you wound up in the "add all node intervals" branch of the big "if" at each level of the tree -- since it pushes two nodes onto the stack rather than one it could briefly result in _treeHeight + 1 stack entries.