### PR TITLE
QueryWithoutLimits implementation

### DIFF
--- a/Source/IntervalTree/IIntervalTree.cs
+++ b/Source/IntervalTree/IIntervalTree.cs
@@ -35,6 +35,15 @@ public interface IIntervalTree<TKey, TValue> : IEnumerable<Interval<TKey, TValue
     IEnumerable<TValue> Query(TKey low, TKey high);
 
     /// <summary>
+    /// Find the values associated with all intervals overlapping the provided range.
+    /// Note that two intervals with touching limits are excluded.
+    /// Note that the tree will first be built if required.
+    /// </summary>
+    /// <param name="target">The range to test against stored intervals</param>
+    /// <returns>Values associated with matching intervals</returns>
+    IEnumerable<TValue> QueryWithoutLimits(TKey low, TKey high);
+
+    /// <summary>
     /// Remove all intervals with matching associated value.
     /// </summary>
     /// <param name="value">Value to look for</param>

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -230,11 +230,11 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     var interval = _intervals[i];
 
                     var compareFrom = high.CompareTo(interval.From);
-                    if (compareFrom < 0)
+                    if (compareFrom <= 0)
                         break;
 
                     var compareTo = low.CompareTo(interval.To);
-                    if (compareTo > 0)
+                    if (compareTo >= 0)
                         continue;
 
                     results ??= new List<TValue>();
@@ -247,7 +247,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 var interval = _intervals[center];
 
                 var compareMax = low.CompareTo(interval.Max);
-                if (compareMax > 0) continue; // target larger than Max, bail
+                if (compareMax >= 0) continue; // target larger than or equal to Max, bail
 
                 // search left
                 stack[++stackIndex] = min;
@@ -256,7 +256,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 // check current node
                 var compareFrom = high.CompareTo(interval.From);
 
-                if (compareFrom < 0) continue; // target smaller than From, bail
+                if (compareFrom <= 0) continue; // target smaller than or equal to From, bail
                 else
                 {
                     var compareTo = low.CompareTo(interval.To);

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -199,6 +199,83 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
         return results is null ? Enumerable.Empty<TValue>() : results;
     }
 
+    public IEnumerable<TValue> QueryWithoutLimits(TKey low, TKey high)
+    {
+                if (high.CompareTo(low) < 0)
+            throw new ArgumentException("Argument 'high' must not be smaller than argument 'low'", nameof(high));
+
+        if (_isBuilt is false)
+            Build();
+
+        if (_count == 0)
+            return Enumerable.Empty<TValue>();
+
+        List<TValue>? results = null;
+
+        Span<int> stack = stackalloc int[2 * _treeHeight];
+        stack[0] = 0;
+        stack[1] = _count - 1;
+        var stackIndex = 1;
+
+        while (stackIndex > 0)
+        {
+            var max = stack[stackIndex--];
+            var min = stack[stackIndex--];
+
+            var span = max - min;
+            if (span < 6) // At small subtree sizes a linear scan is faster
+            {
+                for (var i = min; i <= max; i++)
+                {
+                    var interval = _intervals[i];
+
+                    var compareFrom = high.CompareTo(interval.From);
+                    if (compareFrom < 0)
+                        break;
+
+                    var compareTo = low.CompareTo(interval.To);
+                    if (compareTo > 0)
+                        continue;
+
+                    results ??= new List<TValue>();
+                    results.Add(interval.Value);
+                }
+            }
+            else
+            {
+                var center = (min + max + 1) / 2;
+                var interval = _intervals[center];
+
+                var compareMax = low.CompareTo(interval.Max);
+                if (compareMax > 0) continue; // target larger than Max, bail
+
+                // search left
+                stack[++stackIndex] = min;
+                stack[++stackIndex] = center - 1;
+
+                // check current node
+                var compareFrom = high.CompareTo(interval.From);
+
+                if (compareFrom < 0) continue; // target smaller than From, bail
+                else
+                {
+                    var compareTo = low.CompareTo(interval.To);
+                    if (compareTo <= 0)
+                    {
+                        results ??= new List<TValue>();
+                        results.Add(interval.Value);
+                    }
+                }
+
+                // search right
+                stack[++stackIndex] = center + 1;
+                stack[++stackIndex] = max;
+            }
+        }
+
+        return results is null ? Enumerable.Empty<TValue>() : results;
+    }
+
     /// <summary>
     /// Build the underlying tree structure.
     /// A build is automatically performed, if needed, on the first query after altering the tree.

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -115,11 +115,11 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             var interval = _intervals[i];
 
             var compareFrom = high.CompareTo(interval.From);
-            if (compareFrom < 0)
+            if (compareFrom <= 0)
                 continue;
 
             var compareTo = low.CompareTo(interval.To);
-            if (compareTo > 0)
+            if (compareTo >= 0)
                 continue;
 
             results ??= new List<TValue>();

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -100,6 +100,35 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
         return results is null ? Enumerable.Empty<TValue>() : results;
     }
 
+    public IEnumerable<TValue> QueryWithoutLimits(TKey low, TKey high)
+    {
+        if (high.CompareTo(low) < 0)
+            throw new ArgumentException("Argument 'high' must not be smaller than argument 'low'", nameof(high));
+
+        if (_count == 0)
+            return Enumerable.Empty<TValue>();
+
+        List<TValue>? results = null;
+
+        for (var i = 0; i < _count; i++)
+        {
+            var interval = _intervals[i];
+
+            var compareFrom = high.CompareTo(interval.From);
+            if (compareFrom < 0)
+                continue;
+
+            var compareTo = low.CompareTo(interval.To);
+            if (compareTo > 0)
+                continue;
+
+            results ??= new List<TValue>();
+            results.Add(interval.Value);
+        }
+
+        return results is null ? Enumerable.Empty<TValue>() : results;
+    }
+
     public void Remove(TValue value)
     {
         var i = 0;

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -236,6 +236,104 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
         return result ?? Enumerable.Empty<TValue>();
     }
 
+    public IEnumerable<TValue> QueryWithoutLimits(TKey low, TKey high)
+    {
+        if (high.CompareTo(low) < 0)
+            throw new ArgumentException("Argument 'high' must not be smaller than argument 'low'", nameof(high));
+
+        if (_isBuilt is false)
+            Build();
+
+        List<TValue>? result = null;
+
+        Span<int> stack = stackalloc int[_treeHeight];
+        stack[0] = 1;
+        var stackIndex = 0;
+
+        while (stackIndex >= 0)
+        {
+            var nodeIndex = stack[stackIndex--];
+
+            var node = _nodes[nodeIndex];
+
+            if (node.IntervalCount == 0) continue;
+
+            //var centerComparison = target.CompareTo(node.Center);
+            var compareLow = low.CompareTo(node.Center);
+            var compareHigh = high.CompareTo(node.Center);
+
+            if (compareHigh < 0)
+            {
+                // look left
+                // test node intervals for overlap
+                for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
+                {
+                    var intv = _intervals[i];
+                    if (high.CompareTo(intv.From) >= 0)
+                    {
+                        result ??= new List<TValue>();
+                        result.Add(intv.Value);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                if (node.Next is not 0)
+                {
+                    // queue left child
+                    stack[++stackIndex] = node.Next;
+                }
+            }
+            else if (compareLow > 0)
+            {
+                // look right
+                // test node intervals for overlap
+                for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
+                {
+                    var half = _intervalsDescending[i];
+                    if (low.CompareTo(half.Start) <= 0)
+                    {
+                        var full = _intervals[half.Index];
+                        result ??= new List<TValue>();
+                        result.Add(full.Value);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                if (node.Next is not 0)
+                {
+                    // queue right child
+                    stack[++stackIndex] = node.Next + 1;
+                }
+            }
+            else
+            {
+                // add all node intervals
+                for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
+                {
+                    var intv = _intervals[i];
+                    result ??= new List<TValue>();
+                    result.Add(intv.Value);
+                }
+
+                if (node.Next is not 0)
+                {
+                    // queue left child
+                    stack[++stackIndex] = node.Next;
+                    // queue right child
+                    stack[++stackIndex] = node.Next + 1;
+                }
+            }
+        }
+
+        return result ?? Enumerable.Empty<TValue>();
+    }
+
     /// <summary>
     /// Build the underlying tree structure.
     /// A build is automatically performed, if needed, on the first query after altering the tree.

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -262,14 +262,14 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             var compareLow = low.CompareTo(node.Center);
             var compareHigh = high.CompareTo(node.Center);
 
-            if (compareHigh < 0)
+            if (compareHigh <= 0)
             {
                 // look left
                 // test node intervals for overlap
                 for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
                 {
                     var intv = _intervals[i];
-                    if (high.CompareTo(intv.From) >= 0)
+                    if (high.CompareTo(intv.From) > 0)
                     {
                         result ??= new List<TValue>();
                         result.Add(intv.Value);
@@ -293,7 +293,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
                 {
                     var half = _intervalsDescending[i];
-                    if (low.CompareTo(half.Start) <= 0)
+                    if (low.CompareTo(half.Start) < 0)
                     {
                         var full = _intervals[half.Index];
                         result ??= new List<TValue>();

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -154,6 +154,18 @@ public class UnitTests
 
         [Test]
         [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
+        public void WhenQueriedRangeOnFromValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.Query(5, 10);
+
+            Assert.That(results.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
         public void WhenQueriedRangeAcrossFromValue_ReturnsMatch(string treeType)
         {
             var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
@@ -193,12 +205,184 @@ public class UnitTests
 
         [Test]
         [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
+        public void WhenQueriedRangeOnToValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.Query(19, 23);
+
+            Assert.That(results.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
         public void WhenQueriedRangeAfterToValue_Returns0Matches(string treeType)
         {
             var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
             tree.Add(10, 19, 1);
 
             var results = tree.Query(22, 25);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeBeforeFromValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(5, 8);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(5, 8);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeOnFromValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(5, 10);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(5, 10);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeAcrossFromValue_ReturnsMatch(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(8, 12);
+
+            Assert.That(results.Count(), Is.EqualTo(1));
+            Assert.That(results.First(), Is.EqualTo(1));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(8, 12);
+
+            Assert.That(results.Count(), Is.EqualTo(7));
+            Assert.That(results.First(), Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeInsideInterval_ReturnsMatch(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(12, 15);
+
+            Assert.That(results.Count(), Is.EqualTo(1));
+            Assert.That(results.First(), Is.EqualTo(1));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(12, 15);
+
+            Assert.That(results.Count(), Is.EqualTo(7));
+            Assert.That(results.First(), Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeAcrossTo_ReturnsMatch(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(18, 23);
+
+            Assert.That(results.Count(), Is.EqualTo(1));
+            Assert.That(results.First(), Is.EqualTo(1));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(18, 23);
+
+            Assert.That(results.Count(), Is.EqualTo(7));
+            Assert.That(results.First(), Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeOnToValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(19, 23);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(19, 23);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void WhenQueriedWithoutLimitsRangeAfterToValue_Returns0Matches(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTreeSansReference<long, int>(treeType);
+            tree.Add(10, 19, 1);
+
+            var results = tree.QueryWithoutLimits(22, 25);
+
+            Assert.That(results.Count(), Is.EqualTo(0));
+
+            // Add 6 more entries to test light version correctly
+            for (int i = 0; i < 6; i++)
+            {
+                tree.Add(10, 19, 1);
+            }
+
+            results = tree.QueryWithoutLimits(22, 25);
 
             Assert.That(results.Count(), Is.EqualTo(0));
         }

--- a/Tools/Extras/TreeFactory.cs
+++ b/Tools/Extras/TreeFactory.cs
@@ -26,6 +26,11 @@ public static class TreeFactory
         return new TreeAdapter<TKey, TValue>((IIntervalTree<TKey, TValue>)tree);
     }
 
+    public static IIntervalTree<TKey, TValue> CreateEmptyTreeSansReference<TKey, TValue>(string type, int? capacity = null) where TKey : IComparable<TKey>
+    {
+        return (IIntervalTree<TKey, TValue>)CreateEmptyTreeRaw<TKey, TValue>(type, capacity);
+    }
+
     public static object CreateEmptyTreeRaw<TKey, TValue>(string type, int? capacity = null) where TKey : IComparable<TKey>
     { 
         if (capacity is null)


### PR DESCRIPTION
Thanks for your nice implementation!

I had the use case to do queries, which do not "trigger", if the intervals only touch at there lower and upper limits.
I copied the Query methods (1. commit) and changed them slightly (2. commit) to make it easier to understand.

I know, that this project is a drop-in replacement for the RangeTree project, but maybe you are interested to integrate this feature.


