### PR TITLE
Implement `RemoveWhere` for bulk item removal

### DIFF
--- a/Source/IntervalTree/IIntervalTree.cs
+++ b/Source/IntervalTree/IIntervalTree.cs
@@ -45,7 +45,7 @@ public interface IIntervalTree<TKey, TValue> : IEnumerable<Interval<TKey, TValue
     /// </summary>
     /// <param name="predicate">Predicate to test values against</param>
     /// <param name="state">State to pass to the predicate</param>
-    void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state);
+    void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state);
 
     /// <summary>
     /// Remove all intervals with a value matching one of the provided values.

--- a/Source/IntervalTree/IIntervalTree.cs
+++ b/Source/IntervalTree/IIntervalTree.cs
@@ -45,7 +45,7 @@ public interface IIntervalTree<TKey, TValue> : IEnumerable<Interval<TKey, TValue
     /// </summary>
     /// <param name="predicate">Predicate to test values against</param>
     /// <param name="state">State to pass to the predicate</param>
-    void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state);
+    void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state);
 
     /// <summary>
     /// Remove all intervals with a value matching one of the provided values.

--- a/Source/IntervalTree/IIntervalTree.cs
+++ b/Source/IntervalTree/IIntervalTree.cs
@@ -39,6 +39,13 @@ public interface IIntervalTree<TKey, TValue> : IEnumerable<Interval<TKey, TValue
     /// </summary>
     /// <param name="value">Value to look for</param>
     void Remove(TValue value);
+    
+    /// <summary>
+    /// Remove all values where the value matches the provided predicate. State is passed to the predicate.
+    /// </summary>
+    /// <param name="predicate">Predicate to test values against</param>
+    /// <param name="state">State to pass to the predicate</param>
+    void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state);
 
     /// <summary>
     /// Remove all intervals with a value matching one of the provided values.

--- a/Source/IntervalTree/IIntervalTree.cs
+++ b/Source/IntervalTree/IIntervalTree.cs
@@ -39,19 +39,19 @@ public interface IIntervalTree<TKey, TValue> : IEnumerable<Interval<TKey, TValue
     /// </summary>
     /// <param name="value">Value to look for</param>
     void Remove(TValue value);
-    
-    /// <summary>
-    /// Remove all values where the value matches the provided predicate. State is passed to the predicate.
-    /// </summary>
-    /// <param name="predicate">Predicate to test values against</param>
-    /// <param name="state">State to pass to the predicate</param>
-    void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state);
 
     /// <summary>
     /// Remove all intervals with a value matching one of the provided values.
     /// </summary>
     /// <param name="value">Values to look for</param>
     void Remove(IEnumerable<TValue> values);
+
+    /// <summary>
+    /// Remove all values where the value matches the provided predicate. State is passed to the predicate.
+    /// </summary>
+    /// <param name="predicate">Predicate to test values against</param>
+    /// <param name="state">State to pass to the predicate</param>
+    void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state);
 
     /// <summary>
     /// Clear all data from tree. Allows for reusing of trees, instead of allocating a new ones.

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -275,6 +275,12 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             value);
     }
 
+    public void Remove(IEnumerable<TValue> values)
+    {
+        foreach (var val in values)
+            Remove(val);
+    }
+
     public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
@@ -292,12 +298,6 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 i++;
             }
         }
-    }
-
-    public void Remove(IEnumerable<TValue> values)
-    {
-        foreach (var val in values)
-            Remove(val);
     }
 
     public void Clear()

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -44,7 +44,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
     }
 
     public IEnumerator<Interval<TKey, TValue>> GetEnumerator() => 
-        _intervals.Take(_count).Select(i => new Interval<TKey, TValue>(i.From, i.To, i.Value)).GetEnumerator();
+        _intervals.Take(_count).Select(i => i.ToInterval()).GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -270,16 +270,18 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(
+            static (interval, val) => Equals(interval.Value, val),
+            value);
     }
 
-    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _count)
         {
-            var interval = _intervals[i];
-            if (predicate(interval.Value, state))
+            var interval = _intervals[i].ToInterval();
+            if (predicate(interval, state))
             {
                 _count--;
                 _intervals[i] = _intervals[_count];
@@ -331,5 +333,8 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 return fromComparison;
             return To.CompareTo(other.To);
         }
+
+        public readonly Interval<TKey, TValue> ToInterval()
+            => new(From, To, Value);
     }
 }

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -270,10 +270,10 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
     }
 
-    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _count)

--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -270,11 +270,16 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
+        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+    }
+
+    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    {
         var i = 0;
         while (i < _count)
         {
             var interval = _intervals[i];
-            if (Equals(interval.Value, value))
+            if (predicate(interval.Value, state))
             {
                 _count--;
                 _intervals[i] = _intervals[_count];

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -102,16 +102,18 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(
+            static (interval, val) => Equals(interval.Value, val),
+            value);
     }
 
-    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _count)
         {
             var interval = _intervals[i];
-            if (predicate(interval.Value, state))
+            if (predicate(interval, state))
                 _intervals[i] = _intervals[--_count];
             else
                 i++;

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -102,10 +102,10 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
     }
 
-    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _count)

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -107,6 +107,12 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             value);
     }
 
+    public void Remove(IEnumerable<TValue> values)
+    {
+        foreach (var val in values)
+            Remove(val);
+    }
+
     public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
@@ -118,12 +124,6 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             else
                 i++;
         }
-    }
-
-    public void Remove(IEnumerable<TValue> values)
-    {
-        foreach (var val in values)
-            Remove(val);
     }
 
     public void Clear()

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -102,11 +102,16 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
+        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+    }
+
+    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    {
         var i = 0;
         while (i < _count)
         {
             var interval = _intervals[i];
-            if (Equals(interval.Value, value))
+            if (predicate(interval.Value, state))
                 _intervals[i] = _intervals[--_count];
             else
                 i++;

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -379,11 +379,16 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
+        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+    }
+    
+    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    {
         var i = 0;
         while (i < _intervalCount)
         {
             var interval = _intervals[i];
-            if (Equals(interval.Value, value))
+            if (predicate(interval.Value, state))
             {
                 _intervalCount--;
                 _intervals[i] = _intervals[_intervalCount];
@@ -395,12 +400,14 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             }
         }
     }
-
+    
     public void Remove(IEnumerable<TValue> values)
     {
         foreach (var val in values)
             Remove(val);
     }
+    
+
 
     public void Clear()
     {

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -379,10 +379,10 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveWhere(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
     }
     
-    public void RemoveWhere<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _intervalCount)

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -379,16 +379,18 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
 
     public void Remove(TValue value)
     {
-        RemoveAll(static (toFind, v) => v!.Equals(toFind), value);
+        RemoveAll(
+            static (interval, val) => Equals(interval.Value, val),
+            value);
     }
     
-    public void RemoveAll<TState>(Func<TValue, TState, bool> predicate, TState state)
+    public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
         while (i < _intervalCount)
         {
             var interval = _intervals[i];
-            if (predicate(interval.Value, state))
+            if (predicate(interval, state))
             {
                 _intervalCount--;
                 _intervals[i] = _intervals[_intervalCount];

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -383,7 +383,13 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             static (interval, val) => Equals(interval.Value, val),
             value);
     }
-    
+
+    public void Remove(IEnumerable<TValue> values)
+    {
+        foreach (var val in values)
+            Remove(val);
+    }
+
     public void RemoveAll<TState>(Func<Interval<TKey, TValue>, TState, bool> predicate, TState state)
     {
         var i = 0;
@@ -402,14 +408,6 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             }
         }
     }
-    
-    public void Remove(IEnumerable<TValue> values)
-    {
-        foreach (var val in values)
-            Remove(val);
-    }
-    
-
 
     public void Clear()
     {

--- a/Tests/UnitTests.cs
+++ b/Tests/UnitTests.cs
@@ -740,4 +740,110 @@ public class UnitTests
             Assert.That(intervals, Is.EquivalentTo(Enumerable.Range(0, 3).Select(_ => new IntervalTree.RangeValuePair<long, int>(1, 2, 1))));
         }
     }
+
+    public class Removing : UnitTests
+    {
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
+        public void FromAnEmptyTree_DoNothing(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
+
+            tree.Remove(1);
+
+            Assert.That(tree.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
+        public void FromATreeWithMultipleOfSameValue_RemovesAllOccurences(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
+            tree.Add(1, 3, 5);
+            tree.Add(1, 3, 5);
+            tree.Add(41, 300, 5);
+            tree.Add(20, 21, 6);
+
+            tree.Remove(5);
+
+            Assert.That(tree.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypes))]
+        public void FromATreeUsingEnumerable_RemovesAllOccurences(string treeType)
+        {
+            var tree = TreeFactory.CreateEmptyTree<long, int>(treeType);
+            
+            tree.Add(1, 3, 5);
+            tree.Add(1, 3, 5);
+            tree.Add(20, 21, 6);
+            tree.Add(41, 300, 5);
+            tree.Add(20, 22, 6);
+
+            tree.Add(10, 20, 7);
+            tree.Add(20, 30, 8);
+
+            tree.Remove([5, 6]);
+
+            Assert.That(tree.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void FromATreeUsingPredicate_RemovesAllOccurencesByValue(string treeType)
+        {
+            var tree = TreeFactory.CreateNonReferenceTree<long, int>(treeType);
+
+            tree.Add(1, 3, 5);
+            tree.Add(1, 3, 5);
+            tree.Add(20, 21, 6);
+            tree.Add(41, 300, 5);
+            tree.Add(20, 22, 6);
+            tree.Add(10, 20, 7);
+            tree.Add(20, 30, 8);
+
+            tree.RemoveAll((intv, _) => intv.Value is 5 or 6, 0);
+
+            Assert.That(tree.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void FromATreeUsingPredicate_RemovesAllOccurencesByFrom(string treeType)
+        {
+            var tree = TreeFactory.CreateNonReferenceTree<long, int>(treeType);
+
+            tree.Add(1, 3, 5);
+            tree.Add(1, 3, 5);
+            tree.Add(41, 300, 5);
+            tree.Add(20, 21, 6);
+            tree.Add(20, 22, 6);
+            tree.Add(10, 20, 7);
+            tree.Add(20, 30, 8);
+
+            tree.RemoveAll((intv, _) => intv.From is 20, 0);
+
+            Assert.That(tree.Count, Is.EqualTo(4));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TreeFactory), nameof(TreeFactory.TreeTypesSansReference))]
+        public void FromATreeUsingPredicate_RemovesAllOccurencesByTo(string treeType)
+        {
+            var tree = TreeFactory.CreateNonReferenceTree<long, int>(treeType);
+
+            tree.Add(1, 3, 5);
+            tree.Add(1, 3, 5);
+            tree.Add(41, 300, 5);
+            tree.Add(20, 21, 6);
+            tree.Add(20, 22, 6);
+            tree.Add(10, 20, 7);
+            tree.Add(20, 30, 8);
+
+            tree.RemoveAll((intv, _) => intv.To is 21 or 22, 0);
+
+            Assert.That(tree.Count, Is.EqualTo(5));
+        }
+    }
 }

--- a/Tools/Extras/TreeFactory.cs
+++ b/Tools/Extras/TreeFactory.cs
@@ -26,6 +26,12 @@ public static class TreeFactory
         return new TreeAdapter<TKey, TValue>((IIntervalTree<TKey, TValue>)tree);
     }
 
+    public static IIntervalTree<TKey, TValue> CreateNonReferenceTree<TKey, TValue>(string type, int? capacity = null)
+        where TKey : IComparable<TKey>
+    {
+        return (IIntervalTree<TKey, TValue>)CreateEmptyTreeRaw<TKey, TValue>(type, capacity);
+    }
+
     public static object CreateEmptyTreeRaw<TKey, TValue>(string type, int? capacity = null) where TKey : IComparable<TKey>
     { 
         if (capacity is null)


### PR DESCRIPTION
The `O(n)` on removal isn't so bad, until you need to bulk remove a bunch of items. In that case it would be nice to still have `O(n)` instead of `O(n*m)`. This PR keeps the existing interfaces but re-implementes `Remove` via an abstract predicate function so that bulk removal can be done via something like a hashset or any other custom logic.