### PR TITLE
Used ArrayPool and `yield return` instead of `new Span`/`new List`

### DIFF
--- a/Source/IntervalTree/LightIntervalTree.cs
+++ b/Source/IntervalTree/LightIntervalTree.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections;
 
 namespace Jamarino.IntervalTree;
@@ -54,11 +55,9 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             Build();
 
         if (_count == 0)
-            return Enumerable.Empty<TValue>();
+            yield break;
 
-        List<TValue>? results = null;
-
-        Span<int> stack = stackalloc int[2 * _treeHeight];
+        int[] stack = ArrayPool<int>.Shared.Rent(2 * _treeHeight);
         stack[0] = 0;
         stack[1] = _count - 1;
         var stackIndex = 1;
@@ -83,8 +82,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     if (compareTo > 0)
                         continue;
 
-                    results ??= new List<TValue>();
-                    results.Add(interval.Value);
+                    yield return interval.Value;
                 }
             }
             else
@@ -108,8 +106,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     var compareTo = target.CompareTo(interval.To);
                     if (compareTo <= 0)
                     {
-                        results ??= new List<TValue>();
-                        results.Add(interval.Value);
+                        yield return interval.Value;
                     }
                 }
 
@@ -118,8 +115,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 stack[++stackIndex] = max;
             }
         }
-
-        return results is null ? Enumerable.Empty<TValue>() : results;
+        ArrayPool<int>.Shared.Return(stack);
     }
 
     public IEnumerable<TValue> Query(TKey low, TKey high)
@@ -131,11 +127,9 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             Build();
 
         if (_count == 0)
-            return Enumerable.Empty<TValue>();
+            yield break;
 
-        List<TValue>? results = null;
-
-        Span<int> stack = stackalloc int[2 * _treeHeight];
+        int[] stack = ArrayPool<int>.Shared.Rent(2 * _treeHeight);
         stack[0] = 0;
         stack[1] = _count - 1;
         var stackIndex = 1;
@@ -160,8 +154,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     if (compareTo > 0)
                         continue;
 
-                    results ??= new List<TValue>();
-                    results.Add(interval.Value);
+                    yield return interval.Value;
                 }
             }
             else
@@ -185,8 +178,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     var compareTo = low.CompareTo(interval.To);
                     if (compareTo <= 0)
                     {
-                        results ??= new List<TValue>();
-                        results.Add(interval.Value);
+                        yield return interval.Value;
                     }
                 }
 
@@ -196,7 +188,7 @@ public class LightIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             }
         }
 
-        return results is null ? Enumerable.Empty<TValue>() : results;
+        ArrayPool<int>.Shared.Return(stack);
     }
 
     /// <summary>

--- a/Source/IntervalTree/LinearIntervalTree.cs
+++ b/Source/IntervalTree/LinearIntervalTree.cs
@@ -48,9 +48,7 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
     public IEnumerable<TValue> Query(TKey target)
     {
         if (_count is 0)
-            return Enumerable.Empty<TValue>();
-
-        List<TValue>? results = null;
+            yield break;
 
         for (var i = 0; i < _count; i++)
         {
@@ -64,11 +62,8 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             if (compareTo > 0)
                 continue;
 
-            results ??= new List<TValue>();
-            results.Add(interval.Value);
+            yield return interval.Value;
         }
-
-        return results is null ? Enumerable.Empty<TValue>() : results;
     }
 
     public IEnumerable<TValue> Query(TKey low, TKey high)
@@ -77,9 +72,7 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             throw new ArgumentException("Argument 'high' must not be smaller than argument 'low'", nameof(high));
 
         if (_count == 0)
-            return Enumerable.Empty<TValue>();
-
-        List<TValue>? results = null;
+            yield break;
 
         for (var i = 0; i < _count; i++)
         {
@@ -93,11 +86,8 @@ public class LinearIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             if (compareTo > 0)
                 continue;
 
-            results ??= new List<TValue>();
-            results.Add(interval.Value);
+            yield return interval.Value;
         }
-
-        return results is null ? Enumerable.Empty<TValue>() : results;
     }
 
     public void Remove(TValue value)

--- a/Source/IntervalTree/QuickIntervalTree.cs
+++ b/Source/IntervalTree/QuickIntervalTree.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections;
 
 namespace Jamarino.IntervalTree;
@@ -57,9 +58,8 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
         if (_isBuilt is false)
             Build();
 
-        List<TValue>? result = null;
 
-        Span<int> stack = stackalloc int[_treeHeight];
+        int[] stack = ArrayPool<int>.Shared.Rent(_treeHeight);
         stack[0] = 1;
         var stackIndex = 0;
 
@@ -82,8 +82,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     var intv = _intervals[i];
                     if (target.CompareTo(intv.From) >= 0)
                     {
-                        result ??= new List<TValue>();
-                        result.Add(intv.Value);
+                        yield return intv.Value;
                     }
                     else
                     {
@@ -107,8 +106,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     if (target.CompareTo(half.Start) <= 0)
                     {
                         var full = _intervals[half.Index];
-                        result ??= new List<TValue>();
-                        result.Add(full.Value);
+                        yield return full.Value;
                     }
                     else
                     {
@@ -129,13 +127,12 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
                 {
                     var intv = _intervals[i];
-                    result ??= new List<TValue>();
-                    result.Add(intv.Value);
+                    yield return intv.Value;
                 }
             }
         }
 
-        return result ?? Enumerable.Empty<TValue>();
+        ArrayPool<int>.Shared.Return(stack);
     }
 
     public IEnumerable<TValue> Query(TKey low, TKey high)
@@ -146,9 +143,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
         if (_isBuilt is false)
             Build();
 
-        List<TValue>? result = null;
-
-        Span<int> stack = stackalloc int[_treeHeight];
+        int[] stack = ArrayPool<int>.Shared.Rent(_treeHeight);
         stack[0] = 1;
         var stackIndex = 0;
 
@@ -173,8 +168,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     var intv = _intervals[i];
                     if (high.CompareTo(intv.From) >= 0)
                     {
-                        result ??= new List<TValue>();
-                        result.Add(intv.Value);
+                        yield return intv.Value;
                     }
                     else
                     {
@@ -198,8 +192,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                     if (low.CompareTo(half.Start) <= 0)
                     {
                         var full = _intervals[half.Index];
-                        result ??= new List<TValue>();
-                        result.Add(full.Value);
+                        yield return full.Value;
                     }
                     else
                     {
@@ -219,8 +212,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
                 for (var i = node.IntervalIndex; i < node.IntervalIndex + node.IntervalCount; i++)
                 {
                     var intv = _intervals[i];
-                    result ??= new List<TValue>();
-                    result.Add(intv.Value);
+                    yield return intv.Value;
                 }
 
                 if (node.Next is not 0)
@@ -233,7 +225,7 @@ public class QuickIntervalTree<TKey, TValue> : IIntervalTree<TKey, TValue>
             }
         }
 
-        return result ?? Enumerable.Empty<TValue>();
+        ArrayPool<int>.Shared.Return(stack);
     }
 
     /// <summary>


### PR DESCRIPTION
This change significantly improves memory usage of `Query` calls when a lot of colliding ranges are found. 
The benchmarks from this repository don't show any improvements for some reason, but the following one shows quite a huge improvement:

```cs

[MemoryDiagnoser]
public class IntervalTreeBenchmarks
{
    private readonly QuickIntervalTree<uint, uint> _quickIntervalTree = new();
    private uint[] _points = new uint[10_000];

    [GlobalSetup]
    public void Setup()
    {
        for (int i = 0; i < _points.Length; ++i)
        {
            uint low = (uint)Random.Shared.Next(10_000);
            uint high = (uint)Random.Shared.Next((int)low + 1, 20_000);

            _quickIntervalTree.Add(low, high, (uint)Random.Shared.Next(20_000));
            _points[i] = (uint)Random.Shared.Next();
        }
    }

    [Benchmark(Baseline = true)]
    public void Old()
    {
        for (uint i = 0; i < _points.Length; ++i)
        {
            int count = 0;
            foreach (uint u in _quickIntervalTree.Query(i))
            {
                ++count;
            }
        }
    }

    [Benchmark]
    public void New()
    {
        for (uint i = 0; i < _points.Length; ++i)
        {
            int count = 0;
            foreach (uint u in _quickIntervalTree.QueryNew(i))
            {
                ++count;
            }
        }
    }
}
```
Results:
| Method | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0       | Gen1      | Allocated    | Alloc Ratio |
|------- |---------:|--------:|--------:|------:|--------:|-----------:|----------:|-------------:|------------:|
| Old    | 142.2 ms | 2.64 ms | 2.71 ms |  1.00 |    0.03 | 36750.0000 | 3750.0000 | 450985.72 KB |       1.000 |
| New    | 131.5 ms | 1.51 ms | 1.18 ms |  0.92 |    0.02 |          - |         - |    781.41 KB |       0.002 |


Maybe there is something wrong with my benchmark code and the code I'm proposing in the PR isn't making any difference, but I couldn't find why that would be the case.